### PR TITLE
:technologist: Simplify demo building

### DIFF
--- a/demos/CMakeLists.txt
+++ b/demos/CMakeLists.txt
@@ -5,6 +5,12 @@ project(demos VERSION 0.0.1 LANGUAGES CXX)
 find_package(libhal-lpc40xx REQUIRED CONFIG)
 find_package(libhal-rmd REQUIRED CONFIG)
 
+if(NOT DEFINED CMAKE_BUILD_TYPE)
+    set(CMAKE_BUILD_TYPE "Debug" CACHE INTERNAL "Default to Debug Build")
+endif(NOT DEFINED CMAKE_BUILD_TYPE)
+
+set(CMAKE_TOOLCHAIN_FILE conan_toolchain.cmake)
+
 set(DEMOS drc)
 set(TARGETS lpc4078 lpc4074)
 


### PR DESCRIPTION
No longer required to specify Debug and cmake_toolchain.cmake with the cmake command