### PR TITLE
:green_heart: Fix demo builds

### DIFF
--- a/demos/applications/drc.cpp
+++ b/demos/applications/drc.cpp
@@ -51,8 +51,8 @@ hal::status application(hardware_map& p_map)
                      drc.feedback().raw_volts,
                      drc.feedback().encoder,
                      drc.feedback().raw_motor_temperature,
-                     drc.feedback().over_voltage_protection_tripped,
-                     drc.feedback().over_temperature_protection_tripped,
+                     drc.feedback().over_voltage_protection_tripped(),
+                     drc.feedback().over_temperature_protection_tripped(),
                      drc.feedback().angle(),
                      drc.feedback().current(),
                      drc.feedback().speed(),
@@ -63,13 +63,13 @@ hal::status application(hardware_map& p_map)
   HAL_CHECK(hal::delay(clock, 500ms));
 
   while (true) {
-    HAL_CHECK(drc.velocity_control(5.0_rpm));
-    print_feedback();
+    HAL_CHECK(drc.velocity_control(10.0_rpm));
     (void)hal::delay(clock, 2000ms);
+    print_feedback();
 
-    HAL_CHECK(drc.velocity_control(-5.0_rpm));
-    print_feedback();
+    HAL_CHECK(drc.velocity_control(-10.0_rpm));
     (void)hal::delay(clock, 2000ms);
+    print_feedback();
   }
 
   return hal::success();

--- a/demos/applications/mc_x.cpp
+++ b/demos/applications/mc_x.cpp
@@ -35,14 +35,21 @@ hal::status application(hardware_map& p_map)
                      "encoder = %d\n"
                      "raw_motor_temperature = %d"
                      "\n"
-                     "over_voltage_protection_tripped = %d\n"
-                     "over_temperature_protection_tripped = %d\n"
                      "-------\n"
                      "angle() = %f °deg\n"
                      "current() = %f A\n"
                      "speed() = %f rpm\n"
                      "volts() = %f V\n"
-                     "temperature() = %f °C\n\n",
+                     "temperature() = %f °C\n"
+                     "motor_stall() = %d\n"
+                     "low_pressure() = %d\n"
+                     "over_voltage() = %d\n"
+                     "over_current() = %d\n"
+                     "power_overrun() = %d\n"
+                     "speeding() = %d\n"
+                     "over_temperature() = %d\n"
+                     "encoder_calibration_error() = %d\n"
+                     "\n",
 
                      mc_x.feedback().message_number,
                      static_cast<float>(mc_x.feedback().raw_multi_turn_angle),
@@ -51,32 +58,53 @@ hal::status application(hardware_map& p_map)
                      mc_x.feedback().raw_volts,
                      mc_x.feedback().encoder,
                      mc_x.feedback().raw_motor_temperature,
-                     mc_x.feedback().over_voltage_protection_tripped,
-                     mc_x.feedback().over_temperature_protection_tripped,
                      mc_x.feedback().angle(),
                      mc_x.feedback().current(),
                      mc_x.feedback().speed(),
                      mc_x.feedback().volts(),
-                     mc_x.feedback().temperature());
+                     mc_x.feedback().temperature(),
+                     mc_x.feedback().motor_stall(),
+                     mc_x.feedback().low_pressure(),
+                     mc_x.feedback().over_voltage(),
+                     mc_x.feedback().over_current(),
+                     mc_x.feedback().power_overrun(),
+                     mc_x.feedback().speeding(),
+                     mc_x.feedback().over_temperature(),
+                     mc_x.feedback().encoder_calibration_error());
   };
 
   while (true) {
-    // mc_x.velocity_control(1.0_rpm);
+    mc_x.velocity_control(1.0_rpm);
     (void)hal::delay(clock, 5000ms);
-    // mc_x.velocity_control(-1.0_rpm);
+    print_feedback();
+
+    mc_x.velocity_control(-1.0_rpm);
     (void)hal::delay(clock, 5000ms);
+    print_feedback();
+
     // mc_x.position_control(0.0_deg, 20.0_rpm);
-    (void)hal::delay(clock, 2000ms);
+    // (void)hal::delay(clock, 2000ms);
+    // print_feedback();
+
     // mc_x.position_control(45.0_deg, 20.0_rpm);
-    (void)hal::delay(clock, 2000ms);
+    // (void)hal::delay(clock, 2000ms);
+    // print_feedback();
+
     // mc_x.position_control(90.0_deg, 20.0_rpm);
-    (void)hal::delay(clock, 2000ms);
+    // (void)hal::delay(clock, 2000ms);
+    // print_feedback();
+
     // mc_x.position_control(180.0_deg, 20.0_rpm);
-    (void)hal::delay(clock, 2000ms);
+    // (void)hal::delay(clock, 2000ms);
+    // print_feedback();
+
     // mc_x.position_control(360.0_deg, 20.0_rpm);
-    (void)hal::delay(clock, 5000ms);
+    // (void)hal::delay(clock, 5000ms);
+    // print_feedback();
+
     // mc_x.position_control(0.0_deg, 20.0_rpm);
-    (void)hal::delay(clock, 2000ms);
+    // (void)hal::delay(clock, 2000ms);
+    // print_feedback();
   }
 
   return hal::success();

--- a/demos/conanfile.txt
+++ b/demos/conanfile.txt
@@ -1,6 +1,6 @@
 [requires]
-libhal-lpc40xx/0.3.12
-libhal-rmd/0.3.8
+libhal-lpc40xx/[^1.0.0]
+libhal-rmd/1.0.0
 
 [tool_requires]
 gnu-arm-embedded-toolchain/11.3.0

--- a/include/libhal-rmd/mc_x.hpp
+++ b/include/libhal-rmd/mc_x.hpp
@@ -153,7 +153,7 @@ public:
     {
       return raw_error_state & speeding_mask;
     }
-    bool motor_temperature_over_temperature() const noexcept
+    bool over_temperature() const noexcept
     {
       return raw_error_state & over_temperature_mask;
     }
@@ -209,6 +209,11 @@ public:
     return m_feedback;
   }
 
+  status feedback_request(read p_command);
+  status velocity_control(rpm p_speed);
+  status position_control(degrees p_angle, rpm speed);
+  status system_control(system p_system_command);
+
   void operator()(const can::message_t& p_message);
 
 private:
@@ -250,13 +255,6 @@ private:
 
     return new_error(std::errc::result_out_of_range);
   }
-
-  // These APIs are hidden until they are working correctly
-
-  status velocity_control(rpm p_speed);
-  status position_control(degrees p_angle, rpm speed);
-  status feedback_request(read p_command);
-  status system_control(system p_system_command);
 
   feedback_t m_feedback{};
   hal::steady_clock* m_clock;


### PR DESCRIPTION
- Move mc_x APIs from private to public to allow the mc_x demo to compile.
- Comment out sections of mc_x demo that do not function properly
- :boom: break the error code API in drc for reading the error states in order to save space and allow for further additions without increasing the size of the feedback object. Version will stay 1.0.0 even though this is a break as no one is currently using 1.0.0 at the moment. Such changes will not be performed when the number of users increases.