### PR TITLE
:bug: Fix bugs with MC_X driver

### DIFF
--- a/demos/applications/drc.cpp
+++ b/demos/applications/drc.cpp
@@ -22,9 +22,9 @@ hal::status application(hardware_map& p_map)
   auto drc = HAL_CHECK(hal::rmd::drc::create(router, clock, 6.0f, 0x142));
 
   auto print_feedback = [&drc, &console]() {
-    drc.feedback_request(hal::rmd::drc::read::status_2);
-    drc.feedback_request(hal::rmd::drc::read::multi_turns_angle);
-    drc.feedback_request(hal::rmd::drc::read::status_1_and_error_flags);
+    (void)drc.feedback_request(hal::rmd::drc::read::status_2);
+    (void)drc.feedback_request(hal::rmd::drc::read::multi_turns_angle);
+    (void)drc.feedback_request(hal::rmd::drc::read::status_1_and_error_flags);
 
     hal::print<2048>(console,
                      "[%u] =================================\n"
@@ -64,11 +64,35 @@ hal::status application(hardware_map& p_map)
 
   while (true) {
     HAL_CHECK(drc.velocity_control(10.0_rpm));
-    (void)hal::delay(clock, 2000ms);
+    (void)hal::delay(clock, 5000ms);
     print_feedback();
 
     HAL_CHECK(drc.velocity_control(-10.0_rpm));
-    (void)hal::delay(clock, 2000ms);
+    (void)hal::delay(clock, 5000ms);
+    print_feedback();
+
+    HAL_CHECK(drc.position_control(0.0_deg, 50.0_rpm));
+    (void)hal::delay(clock, 5000ms);
+    print_feedback();
+
+    HAL_CHECK(drc.position_control(-45.0_deg, 50.0_rpm));
+    (void)hal::delay(clock, 5000ms);
+    print_feedback();
+
+    HAL_CHECK(drc.position_control(90.0_deg, 50.0_rpm));
+    (void)hal::delay(clock, 5000ms);
+    print_feedback();
+
+    HAL_CHECK(drc.position_control(180.0_deg, 50.0_rpm));
+    (void)hal::delay(clock, 5000ms);
+    print_feedback();
+
+    HAL_CHECK(drc.position_control(-360.0_deg, 50.0_rpm));
+    (void)hal::delay(clock, 5000ms);
+    print_feedback();
+
+    HAL_CHECK(drc.position_control(0.0_deg, 50.0_rpm));
+    (void)hal::delay(clock, 5000ms);
     print_feedback();
   }
 

--- a/demos/applications/mc_x.cpp
+++ b/demos/applications/mc_x.cpp
@@ -22,9 +22,9 @@ hal::status application(hardware_map& p_map)
   auto mc_x = HAL_CHECK(hal::rmd::mc_x::create(router, clock, 36.0f, 0x141));
 
   auto print_feedback = [&mc_x, &clock, &console]() {
-    mc_x.feedback_request(hal::rmd::mc_x::read::status_2);
-    mc_x.feedback_request(hal::rmd::mc_x::read::multi_turns_angle);
-    mc_x.feedback_request(hal::rmd::mc_x::read::status_1_and_error_flags);
+    (void)mc_x.feedback_request(hal::rmd::mc_x::read::status_2);
+    (void)mc_x.feedback_request(hal::rmd::mc_x::read::multi_turns_angle);
+    (void)mc_x.feedback_request(hal::rmd::mc_x::read::status_1_and_error_flags);
 
     hal::print<2048>(console,
                      "[%u] =================================\n"
@@ -74,37 +74,37 @@ hal::status application(hardware_map& p_map)
   };
 
   while (true) {
-    mc_x.velocity_control(1.0_rpm);
+    HAL_CHECK(mc_x.velocity_control(50.0_rpm));
+    (void)hal::delay(clock, 10000ms);
+    print_feedback();
+
+    HAL_CHECK(mc_x.velocity_control(-50.0_rpm));
+    (void)hal::delay(clock, 10000ms);
+    print_feedback();
+
+    HAL_CHECK(mc_x.position_control(0.0_deg, 50.0_rpm));
     (void)hal::delay(clock, 5000ms);
     print_feedback();
 
-    mc_x.velocity_control(-1.0_rpm);
+    HAL_CHECK(mc_x.position_control(-45.0_deg, 50.0_rpm));
     (void)hal::delay(clock, 5000ms);
     print_feedback();
 
-    // mc_x.position_control(0.0_deg, 20.0_rpm);
-    // (void)hal::delay(clock, 2000ms);
-    // print_feedback();
+    HAL_CHECK(mc_x.position_control(90.0_deg, 50.0_rpm));
+    (void)hal::delay(clock, 5000ms);
+    print_feedback();
 
-    // mc_x.position_control(45.0_deg, 20.0_rpm);
-    // (void)hal::delay(clock, 2000ms);
-    // print_feedback();
+    HAL_CHECK(mc_x.position_control(180.0_deg, 50.0_rpm));
+    (void)hal::delay(clock, 5000ms);
+    print_feedback();
 
-    // mc_x.position_control(90.0_deg, 20.0_rpm);
-    // (void)hal::delay(clock, 2000ms);
-    // print_feedback();
+    HAL_CHECK(mc_x.position_control(-360.0_deg, 50.0_rpm));
+    (void)hal::delay(clock, 5000ms);
+    print_feedback();
 
-    // mc_x.position_control(180.0_deg, 20.0_rpm);
-    // (void)hal::delay(clock, 2000ms);
-    // print_feedback();
-
-    // mc_x.position_control(360.0_deg, 20.0_rpm);
-    // (void)hal::delay(clock, 5000ms);
-    // print_feedback();
-
-    // mc_x.position_control(0.0_deg, 20.0_rpm);
-    // (void)hal::delay(clock, 2000ms);
-    // print_feedback();
+    HAL_CHECK(mc_x.position_control(0.0_deg, 50.0_rpm));
+    (void)hal::delay(clock, 5000ms);
+    print_feedback();
   }
 
   return hal::success();

--- a/include/libhal-rmd/drc.hpp
+++ b/include/libhal-rmd/drc.hpp
@@ -175,7 +175,22 @@ public:
     }
   };
 
-  static result<drc> create(
+  /**
+   * @brief Create a new drc device driver
+   *
+   * This factory function will power cycle the motor
+   *
+   * @param p_router - can router to use
+   * @param p_clock - clocked used to determine timeouts
+   * @param p_gear_ratio - gear ratio of the motor
+   * @param device_id - The CAN ID of the motor
+   * @param p_max_response_time - maximum amount of time to wait for a response
+   * from the motor.
+   * @return result<drc> - the drc driver or an error
+   * @throws std::errc::timed_out - a response is not returned within the max
+   * response time when attempting to power cycle.
+   */
+  [[nodiscard]] static result<drc> create(
     hal::can_router& p_router,
     hal::steady_clock& p_clock,
     float p_gear_ratio,
@@ -218,10 +233,48 @@ public:
     return *this;
   }
 
-  status velocity_control(rpm p_speed);
-  status position_control(degrees p_angle, rpm speed);
-  status feedback_request(read p_command);
-  status system_control(system p_system_command);
+  /**
+   * @brief Request feedback from the motor
+   *
+   * @param p_command - the request to command the motor to respond with
+   * @return status - success or failure
+   * @throws std::errc::timed_out - if a response is not returned within the max
+   * response time set at creation.
+   */
+  [[nodiscard]] status feedback_request(read p_command);
+
+  /**
+   * @brief Rotate motor shaft at the designated speed
+   *
+   * @param p_speed - speed in rpm to move the motor shaft at. Positive values
+   * rotate the motor shaft clockwise, negative values rotate the motor shaft
+   * counter-clockwise assuming you are looking directly at the motor shaft.
+   * @return status - success or failure
+   * @throws std::errc::timed_out - if a response is not returned within the max
+   * response time set at creation.
+   */
+  [[nodiscard]] status velocity_control(rpm p_speed);
+
+  /**
+   * @brief Move motor shaft to a specific angle
+   *
+   * @param p_angle - angle position in degrees to move to
+   * @param speed - maximum speed in rpm's
+   * @return status - success or failure
+   * @throws std::errc::timed_out - if a response is not returned within the max
+   * response time set at creation.
+   */
+  [[nodiscard]] status position_control(degrees p_angle, rpm speed);
+
+  /**
+   * @brief Send system control commands to the device
+   *
+   * @param p_system_command - system control command to send to the device
+   * @return status - success or failure status
+   * @throws std::errc::timed_out - if a response is not returned within the max
+   * response time set at creation.
+   */
+  [[nodiscard]] status system_control(system p_system_command);
 
   const feedback_t& feedback() const
   {


### PR DESCRIPTION
- :boom: break the error code API in drc for reading the error states in order to save space and allow for further additions without increasing the size of the feedback object.
- Add `[[nodiscard]]` to each API that returns status or result.
- Bump version to 2.0.0
- Document each API for drc & mc_x
- mc_x APIs now waits until a response is returned before returning. This can time out. This fixes a number of bugs with feedback and sending API commands too quickly for the device to handle.