### PR TITLE
:arrow_up: upgrade to libhal-util/3.0.0

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,6 +18,7 @@ project(libhal-rmd VERSION 0.0.1 LANGUAGES CXX)
 
 find_package(libhal REQUIRED CONFIG)
 find_package(libhal-util REQUIRED CONFIG)
+find_package(libhal-canrouter REQUIRED CONFIG)
 
 add_library(libhal-rmd
   src/drc.cpp
@@ -31,6 +32,7 @@ target_compile_features(libhal-rmd PRIVATE cxx_std_20)
 target_link_libraries(libhal-rmd PRIVATE
   libhal::libhal
   libhal::util
+  libhal::canrouter
 )
 
 if(NOT BUILD_TESTING STREQUAL OFF)

--- a/conanfile.py
+++ b/conanfile.py
@@ -25,7 +25,7 @@ required_conan_version = ">=1.50.0"
 
 class libhal_rmd_conan(ConanFile):
     name = "libhal-rmd"
-    version = "3.0.0"
+    version = "3.0.1"
     license = "Apache-2.0"
     url = "https://github.com/conan-io/conan-center-index"
     homepage = "https://libhal.github.io/libhal-rmd"
@@ -74,7 +74,8 @@ class libhal_rmd_conan(ConanFile):
 
     def requirements(self):
         self.requires("libhal/[^2.0.0]")
-        self.requires("libhal-util/[^2.0.0]")
+        self.requires("libhal-util/[^3.0.0]")
+        self.requires("libhal-canrouter/[^1.0.0]")
         self.test_requires("libhal-mock/[^2.0.0]")
         self.test_requires("boost-ext-ut/1.1.9")
 

--- a/demos/conanfile.py
+++ b/demos/conanfile.py
@@ -27,9 +27,8 @@ class demos(ConanFile):
 
     def requirements(self):
         if str(self.options.platform).startswith("lpc40"):
-            self.requires("libhal-lpc40/[^2.0.0]")
-        self.requires("libhal-util/[^2.0.0]")
-        self.requires("libhal-rmd/2.0.0")
+            self.requires("libhal-lpc40/[^2.1.1]")
+        self.requires("libhal-rmd/3.0.1")
 
     def layout(self):
         platform_directory = "build/" + str(self.options.platform)

--- a/include/libhal-rmd/drc.hpp
+++ b/include/libhal-rmd/drc.hpp
@@ -16,7 +16,7 @@
 
 #include <cstdint>
 
-#include <libhal-util/can.hpp>
+#include <libhal-canrouter/can_router.hpp>
 #include <libhal/can.hpp>
 #include <libhal/motor.hpp>
 #include <libhal/rotation_sensor.hpp>

--- a/include/libhal-rmd/mc_x.hpp
+++ b/include/libhal-rmd/mc_x.hpp
@@ -16,7 +16,7 @@
 
 #include <cstdint>
 
-#include <libhal-util/can.hpp>
+#include <libhal-canrouter/can_router.hpp>
 #include <libhal/can.hpp>
 #include <libhal/motor.hpp>
 #include <libhal/rotation_sensor.hpp>

--- a/src/drc.cpp
+++ b/src/drc.cpp
@@ -303,14 +303,14 @@ void drc::operator()(const can::message_t& p_message)
     case hal::value(read::multi_turns_angle): {
       auto& data = p_message.payload;
 
-      m_feedback.raw_multi_turn_angle = hal::bit::value(0U)
-                                          .insert<bit::byte_m<0>>(data[1])
-                                          .insert<bit::byte_m<1>>(data[2])
-                                          .insert<bit::byte_m<2>>(data[3])
-                                          .insert<bit::byte_m<3>>(data[4])
-                                          .insert<bit::byte_m<4>>(data[5])
-                                          .insert<bit::byte_m<5>>(data[6])
-                                          .insert<bit::byte_m<6>>(data[7])
+      m_feedback.raw_multi_turn_angle = hal::bit_value(0U)
+                                          .insert<byte_m<0>>(data[1])
+                                          .insert<byte_m<1>>(data[2])
+                                          .insert<byte_m<2>>(data[3])
+                                          .insert<byte_m<3>>(data[4])
+                                          .insert<byte_m<4>>(data[5])
+                                          .insert<byte_m<5>>(data[6])
+                                          .insert<byte_m<6>>(data[7])
                                           .to<std::int64_t>();
       break;
     }

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -24,6 +24,7 @@ find_package(ut REQUIRED CONFIG)
 find_package(libhal REQUIRED CONFIG)
 find_package(libhal-util REQUIRED CONFIG)
 find_package(libhal-mock REQUIRED CONFIG)
+find_package(libhal-canrouter REQUIRED CONFIG)
 
 add_executable(${PROJECT_NAME}
 
@@ -65,4 +66,5 @@ target_link_libraries(${PROJECT_NAME} PRIVATE
   boost-ext-ut::ut
   libhal::libhal
   libhal::util
-  libhal::mock)
+  libhal::mock
+  libhal::canrouter)

--- a/tests/drc.test.cpp
+++ b/tests/drc.test.cpp
@@ -18,6 +18,7 @@
 
 #include <libhal-mock/can.hpp>
 #include <libhal-mock/steady_clock.hpp>
+#include <libhal-util/can.hpp>
 #include <libhal-util/enum.hpp>
 
 #include <boost/ut.hpp>


### PR DESCRIPTION
libhal-util removes can_router. can_router now resides in libhal-canrouter. This change adds both dependencies to libhal-rmd.